### PR TITLE
Remove references to non-supported boolean field for clinical trials

### DIFF
--- a/app/assets/javascripts/patient.js.coffee
+++ b/app/assets/javascripts/patient.js.coffee
@@ -165,11 +165,6 @@ class hQuery.Patient extends hQuery.Person
   expired: -> @json['expired']
 
   ###*
-  @returns {Boolean} returns true if the patient participated in a clinical trial
-  ###
-  clinicalTrialParticipant: -> @json['clinicalTrialParticipant']
-
-  ###*
   @returns {hQuery.CodedEntryList} A list of {@link hQuery.Encounter} objects
   ###
   encounters: ->

--- a/test/unit/patient_api_test.rb
+++ b/test/unit/patient_api_test.rb
@@ -51,7 +51,6 @@ class PatientApiTest  < Test::Unit::TestCase
     assert_equal 'Care', @context.eval('patient.provider().providerEntity().last()')
     assert_equal 'en', @context.eval('patient.languages()[0].type()[0].code()')
     assert_equal true, @context.eval('patient.expired()')
-    assert_equal false, @context.eval('patient.clinicalTrialParticipant()')
   end
 
   def test_encounters


### PR DESCRIPTION
The patient record model no longer supports a boolean field for clinical trial participant; this pull request removes references to it.
