### PR TITLE
Change dose format returned by PatientAPI to type expected in calculation

### DIFF
--- a/app/assets/javascripts/medication.js.coffee
+++ b/app/assets/javascripts/medication.js.coffee
@@ -200,9 +200,15 @@ class hQuery.Medication  extends hQuery.CodedEntry
   route: -> hQuery.createCodedValue @json['route']
 
   ###*
-  @returns {hQuery.Scalar} the dose
+  @returns {Hash} with two keys: units and scalar
   ###
-  dose: -> new hQuery.Scalar @json['dose'] if @json['dose']
+  dose: ->
+    # In Bonnie, dose can be specified in two different contexts: CMD specification and as a field value; the
+    # CMD version used 'unit' and 'value', while the field value version uses 'units' and 'scalar'; we want to
+    # consolidate the versions, so here we convert everything to the field value style
+    if @json.dose
+      units: @json.dose.units || @json.dose.unit
+      scalar: @json.dose.scalar || @json.dose.value
 
   ###*
   @returns {CodedValue}

--- a/test/unit/patient_api_test.rb
+++ b/test/unit/patient_api_test.rb
@@ -124,7 +124,7 @@ class PatientApiTest  < Test::Unit::TestCase
     assert_equal 1, @context.eval('patient.medications().length')
     assert_equal 24, @context.eval('patient.medications()[0].administrationTiming().period().value()')
     assert @context.eval('patient.medications()[0].administrationTiming().institutionSpecified()')
-    assert_equal 'tablet', @context.eval('patient.medications()[0].dose().unit()')
+    assert_equal 'tablet', @context.eval('patient.medications()[0].dose().units')
     assert_equal 'Multivitamin', @context.eval('patient.medications()[0].medicationInformation().freeTextProductName()')
     assert_equal 1, @context.eval('patient.medications().match({"RxNorm": ["89905"]}).length')
     assert_equal 'C38288', @context.eval('patient.medications()[0].route().code()')


### PR DESCRIPTION
HQMF2JS, when doing filterEventsByField, expects either an object that has either a method or field called "scalar". The Scalar type only offers a value() method, which doesn't even work correctly for a fieldValue, which stores the result in the "scalar" field. So, we stop wrapping the dose in a Scalar class.