### PR TITLE
Add QDM components

### DIFF
--- a/app/assets/javascripts/careexperience.js.coffee
+++ b/app/assets/javascripts/careexperience.js.coffee
@@ -1,0 +1,23 @@
+###*
+@namespace scoping into the hquery namespace
+###
+this.hQuery ||= {}
+
+
+# =require core.coffee
+###*
+This represents all care experience.
+@class
+@augments hQuery.CodedEntry
+@exports CareExperience as hQuery.CareExperience
+###
+class hQuery.CareExperience extends hQuery.CodedEntry
+  constructor: (@json) ->
+    super(@json)
+  
+
+  ###*
+  Value returns the value of the result. This will return an object. The properties of this
+  object are dependent on the type of result.
+  ###
+  value: -> @json['value']

--- a/app/assets/javascripts/core.js.coffee
+++ b/app/assets/javascripts/core.js.coffee
@@ -481,6 +481,12 @@ class hQuery.CodedEntry
   ###
   patientPreference: ->  new hQuery.CodedEntryList @json['patientPreference']
 
+  ###*
+  The health record field is the location within an electronic record where the data should be found
+  @returns {CodedValue}
+  ###
+  healthRecordField: ->  hQuery.createCodedValue @json['health_record_field']
+
 ###*
 @class Represents a list of hQuery.CodedEntry instances. Offers utility methods for matching
 entries based on codes and date ranges

--- a/app/assets/javascripts/patient.js.coffee
+++ b/app/assets/javascripts/patient.js.coffee
@@ -15,6 +15,7 @@
 # =require caregoal.js.coffee
 # =require medicalequipment.js.coffee
 # =require functionalstatus.js.coffee
+# =require careexperience.js.coffee
 
 ###*
 @namespace scoping into the hquery namespace
@@ -235,6 +236,16 @@ class hQuery.Patient extends hQuery.Person
     if @json['family_history']
       for familyhistory in @json['family_history']
         list.pushIfUsable(new hQuery.FamilyHistory(familyhistory))
+    list
+
+  ###*
+  @returns {hQuery.CodedEntryList} A list of {@link CareExperience} objects
+  ###
+  careExperiences: ->
+    list = new hQuery.CodedEntryList
+    if @json['care_experiences']
+      for care_experience in @json['care_experiences']
+        list.pushIfUsable(new hQuery.CareExperience(care_experience))
     list
 
   ###*

--- a/app/assets/javascripts/procedure.js.coffee
+++ b/app/assets/javascripts/procedure.js.coffee
@@ -83,3 +83,11 @@ class hQuery.Procedure extends hQuery.CodedEntry
   @returns {CodedValue}
   ###
   radiationDuration: ->  new hQuery.createCodedValue @json['radiationDuration']
+
+  ###*
+  The resulting status of a procedure as defined in the QDM documentation. This is different
+  than the status_code associated with the `CodedEntry` object, which relates to the data criteria
+  status as defined in health-data-standards/lib/hqmf-model/data_criteria.json.
+  @returns {CodedValue}
+  ###
+  qdmStatus: ->  new hQuery.createCodedValue @json['qdm_status']

--- a/app/assets/javascripts/result.js.coffee
+++ b/app/assets/javascripts/result.js.coffee
@@ -50,3 +50,11 @@ class hQuery.Result extends hQuery.CodedEntry
   @returns {String}
   ###
   comment: -> @json['comment']
+
+  ###*
+  The resulting status of a procedure as defined in the QDM documentation. This is different
+  than the status_code associated with the `CodedEntry` object, which relates to the data criteria
+  status as defined in health-data-standards/lib/hqmf-model/data_criteria.json.
+  @returns {CodedValue}
+  ###
+  qdmStatus: -> hQuery.createCodedValue  @json['qdm_status']


### PR DESCRIPTION
Added several QDM components that were not previously included in Patient API (although they are in QDM 4.2).
These include:

* Care Experience (Patient and Provider)
* Status (for procedure, performed and laboratory results)
* Health Record Field (for all criteria)

Note: `qdm_status` was used instead of `status` because status was already used in `CodedEntry` with a different meaning (which all the models inherit from) than this status. Naming this status `qdm_status` removed issues with conflicts due to overloading a term.