### PR TITLE
Made "Medication, Order" cumulative medication duration calculate correctly.

### DIFF
--- a/app/assets/javascripts/medication.js.coffee
+++ b/app/assets/javascripts/medication.js.coffee
@@ -188,6 +188,22 @@ class hQuery.Medication  extends hQuery.CodedEntry
   administrationTiming: -> new hQuery.AdministrationTiming @json['administrationTiming'] if @json['administrationTiming']
 
   ###*
+  This is used for Medicaton, Order. It is the total number of times a dose of a particular
+  medication can be administered. This, coupled with the administrationTiming will
+  give the cumulative medication duration.
+  E.g.
+    allowedAdministrations = 90 doses
+    administrationTiming = 1 dose / 12 hours
+    cumulativeMedicationDuration = allowedAdministrations / administrationTiming * (time conversion)
+    cumulativeMedicationDuration = (90 doses) * (12 hours)/(1 dose) * (1 day)/(24 hours) = 45 days
+  Medication, Order can't use fulfillmentHistory because the fulfillment of the 
+  medication has not yet happened.
+  This corresponds to 'repeatNumber' in the QRDA representation
+  @returns {Integer}
+  ###
+  allowedAdministrations: -> @json['allowedAdministrations']
+
+  ###*
   @returns {CodedValue}  Contains routeCode or adminstrationUnitCode information.
     Route code shall have a a value drawn from FDA route of administration,
     and indicates how the medication is received by the patient.


### PR DESCRIPTION
This addresses https://oncprojectracking.healthit.gov/support/browse/BONNIE-172.

Usually, cumulative medication duration is calculated based off of the fulfillment history, dose, and regimen. However, for "Medication, Order", the medication has not yet been filled, so fulfillment history and dose don't make sense. Maybe more importantly, these fields are not available in the QRDA for the "Medication, Order" template.

Instead, cumulative medication duration should be calculated based on the maximum allowed administrations (`repeatNumber` in the QRDA) and the regimen (`effectiveTime` with `period` subelement in the QRDA).

Additionally, fulfillment information should not be allowed to be entered for "Medication, Order".

Specific changes for this repository include adding `allowedAdministrations` to the medication model.

This pull request depends on the `medication_order_cmd` branches in **bonnie, hqmf2js, and health-data-standards.**